### PR TITLE
feat: add code completion widget

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import widgetEngine from "./services/widget-engine";
 import { storageService } from "./services/storage-service";
 import { STORAGE_KEYS } from "./constants/storage-keys";
 import { i18n } from "./services/localization-service";
+import { CodeCompletionStrategy } from "./components/widgets/code-completion/code-completion-strategy";
 
 export default class App {
   private readonly parentNode: HTMLElement;
@@ -87,5 +88,6 @@ export default class App {
   private registerWidgets(): void {
     widgetEngine.register(new QuizStrategy());
     widgetEngine.register(new TrueFalseStrategy());
+    widgetEngine.register(new CodeCompletionStrategy());
   }
 }

--- a/src/components/widgets/code-completion/code-completion-strategy.scss
+++ b/src/components/widgets/code-completion/code-completion-strategy.scss
@@ -1,0 +1,95 @@
+.widget {
+  &--true-false {
+    @include flex-column;
+    gap: var(--space-6);
+    max-width: 640px;
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  &--code-completion {
+    @include flex-column;
+    gap: var(--space-6);
+    max-width: 640px;
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  &__code {
+    @include card;
+    @include code-text;
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--text-primary);
+    background: var(--bg-elevated);
+  }
+
+  &__blank {
+    display: inline-block;
+    min-width: 4ch;
+    padding: 2px var(--space-1);
+    margin-inline: var(--space-1);
+    background: var(--bg-surface-hover);
+    border: none;
+    border-bottom: 2px solid var(--accent-primary);
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+    color: var(--accent-primary);
+    font-family: var(--font-mono);
+    font-size: var(--text-base);
+    text-align: center;
+    outline: none;
+    transition:
+      border-color var(--transition-base),
+      background var(--transition-base);
+    vertical-align: middle;
+
+    &:focus {
+      background: var(--accent-primary-light);
+      border-bottom-color: var(--accent-secondary);
+    }
+
+    &--correct {
+      border-bottom-color: var(--accent-success);
+      background: var(--accent-success-light);
+      color: var(--accent-success);
+    }
+
+    &--wrong {
+      border-bottom-color: var(--accent-error);
+      background: var(--accent-error-light);
+      color: var(--accent-error);
+      @include shake;
+    }
+  }
+
+  &__blank-answer {
+    display: inline-block;
+    margin-left: var(--space-1);
+    color: var(--accent-success);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    vertical-align: middle;
+
+    &::before {
+      content: "→ ";
+      opacity: 0.7;
+    }
+  }
+
+  &__hints {
+    @include flex-column;
+    gap: var(--space-2);
+  }
+
+  &__hint {
+    @include label;
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    padding: var(--space-2) var(--space-3);
+    background: var(--accent-warning-light);
+    border-left: 3px solid var(--accent-warning);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  }
+}

--- a/src/components/widgets/code-completion/code-completion-strategy.ts
+++ b/src/components/widgets/code-completion/code-completion-strategy.ts
@@ -1,0 +1,187 @@
+import BaseComponent from "@/components/base/base-component";
+import { Button } from "@/components/button/button";
+import { i18n } from "@/services/localization-service";
+import {
+  WIDGET_TYPES,
+  type ICodeCompletionAnswer,
+  type ICodeCompletionPayload,
+  type IVerdict,
+  type IWidgetStrategy,
+  type Widget,
+  type WidgetAnswerValue,
+} from "@/types/shared/widget.types";
+import "./code-completion-strategy.scss";
+
+const BLANK = "___";
+
+export class CodeCompletionStrategy implements IWidgetStrategy {
+  public type = WIDGET_TYPES.CODE_COMPLETION;
+
+  private inputs: HTMLInputElement[] = [];
+  private submitButton: Button | undefined = undefined;
+
+  public render(
+    widget: Widget,
+    onAnswer: (answer: ICodeCompletionAnswer) => void,
+  ): BaseComponent {
+    if (widget.type !== this.type)
+      throw new Error(
+        `CodeCompletionStrategy received wrong widget type: ${widget.type}`,
+      );
+
+    this.inputs = [];
+    this.submitButton = undefined;
+
+    const payload = widget.payload as ICodeCompletionPayload;
+
+    const container = new BaseComponent({
+      className: "widget widget--code-completion",
+    });
+
+    new BaseComponent({
+      tag: "h2",
+      className: "widget__question",
+      text: i18n.t().widgets.code_completion.header,
+      parent: container,
+    });
+
+    this.renderCode(payload, container);
+    this.renderHints(payload, container);
+    this.submitButton = this.renderSubmitButton(onAnswer, container);
+
+    return container;
+  }
+
+  private renderCode(
+    payload: ICodeCompletionPayload,
+    parent: BaseComponent,
+  ): void {
+    const parts = payload.code.split(BLANK);
+
+    const pre = new BaseComponent({
+      tag: "pre",
+      className: "widget__code",
+      parent,
+    });
+
+    for (const [index, part] of parts.entries()) {
+      pre.getNode().append(document.createTextNode(part));
+
+      if (index < parts.length - 1) {
+        const correctValue =
+          payload.correctValues && payload.correctValues[index]
+            ? payload.correctValues[index]
+            : "";
+
+        const input = document.createElement("input");
+        input.type = "text";
+        input.className = "widget__blank";
+        input.style.width = `${correctValue.length + 2}ch`;
+        input.spellcheck = false;
+
+        input.addEventListener("input", () => {
+          this.submitButton?.setDisabled(!this.allFilled());
+        });
+
+        this.inputs.push(input);
+        pre.addChildren([input]);
+      }
+    }
+  }
+
+  private renderHints(
+    payload: ICodeCompletionPayload,
+    parent: BaseComponent,
+  ): void {
+    if (!payload.hints?.length) return;
+
+    const hintsContainer = new BaseComponent({
+      className: "widget__hints",
+      parent,
+    });
+
+    for (const hint of payload.hints) {
+      new BaseComponent({
+        tag: "p",
+        className: "widget__hint",
+        text: `💡 ${i18n.getLocalizedField(hint)}`,
+        parent: hintsContainer,
+      });
+    }
+  }
+
+  private renderSubmitButton(
+    onAnswer: (answer: ICodeCompletionAnswer) => void,
+    parent: BaseComponent,
+  ): Button {
+    const submitButton = new Button({
+      className: "widget__submit",
+      text: i18n.t().widgets.submit,
+      parent,
+    });
+
+    submitButton.setDisabled(true);
+
+    submitButton.on("click", () => {
+      const values = this.inputs.map((input) => input.value.trim());
+      submitButton.setDisabled(true);
+      onAnswer({ values });
+    });
+
+    return submitButton;
+  }
+
+  private allFilled(): boolean {
+    return this.inputs.every((input) => input.value.trim().length > 0);
+  }
+
+  public validate(answer: ICodeCompletionAnswer, widget: Widget): boolean {
+    if (widget.type !== this.type) return false;
+
+    const payload = widget.payload as ICodeCompletionPayload;
+    if (payload.correctValues === undefined) return false;
+
+    return answer.values.every(
+      (value, index) =>
+        value.toLowerCase() === payload.correctValues?.[index]?.toLowerCase(),
+    );
+  }
+
+  public showVerdict(verdict: IVerdict, widget: Widget): void {
+    if (widget.type !== this.type) return;
+
+    this.submitButton?.getNode().classList.add("widget__submit--hidden");
+
+    const correctValues = verdict.correctAnswer as string[] | undefined;
+
+    for (const [index, input] of this.inputs.entries()) {
+      input.disabled = true;
+
+      if (verdict.isCorrect) {
+        input.classList.add("widget__blank--correct");
+        return;
+      }
+
+      const correctValue = correctValues?.[index];
+      const isCorrect =
+        correctValue !== undefined &&
+        input.value.trim().toLowerCase() === correctValue.toLowerCase();
+
+      input.classList.add(
+        isCorrect ? "widget__blank--correct" : "widget__blank--wrong",
+      );
+
+      if (!isCorrect && correctValue) {
+        const hint = document.createElement("span");
+        hint.className = "widget__blank-answer";
+        hint.textContent = correctValue;
+        input.after(hint);
+      }
+    }
+  }
+
+  public getCorrectValue(widget: Widget): WidgetAnswerValue {
+    const payload = widget.payload as ICodeCompletionPayload;
+    return payload.correctValues;
+  }
+}

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -152,6 +152,9 @@ Can a human understand machine code? Can a human... vibe code a major bug and pu
       true: "True",
       false: "False",
     },
+    code_completion: {
+      header: "Fill in the blanks",
+    },
     stats: {
       xp_earned: "XP Earned",
       xp_icon: "🔸",

--- a/src/locale/ru.ts
+++ b/src/locale/ru.ts
@@ -152,6 +152,9 @@ function curry(func) {
       true: "Верно",
       false: "Неверно",
     },
+    code_completion: {
+      header: "Заполни пропуски",
+    },
     stats: {
       xp_earned: "Заработано XP",
       xp_icon: "🔸",

--- a/src/types/shared/widget.types.ts
+++ b/src/types/shared/widget.types.ts
@@ -131,6 +131,7 @@ export type WidgetAnswerValue =
   | number
   | number[]
   | string
+  | string[]
   | boolean
   | undefined;
 


### PR DESCRIPTION
## 📝 Overview
Implements the CodeCompletion widget — a new widget type where users fill in missing parts of a code snippet inline. Each `___` in the code becomes an input field rendered directly inside the code block.

Closes #87 

## 🚀 Changes
- **`CodeCompletionStrategy`**: new widget strategy implementing `IWidgetStrategy`
  - Parses `payload.code` by splitting on `___`, renders inline `<input>` fields inside `<pre>`
  - Input width calculated dynamically from `correctValues[index].length + 2ch`
  - Submit disabled until all blanks are filled
  - `showVerdict()` highlights each input independently — green/correct, red/wrong, shows correct value below wrong inputs
  - `validate()` compares answers case-insensitively against `correctValues`
  - Hints rendered below code block with warning style if present
- **`widget.types.ts`**: removed `?` from `correctValues` in `ICodeCompletionPayload`
- **`app.ts`**: registered `CodeCompletionStrategy` in `registerWidgets()`
- **`widget.scss`**: added styles for `--code-completion`, `__code`, `__blank`, `__blank-answer`, `__hints`, `__hint`

## 🧪 How to Test
1. `VITE_API_MODE=mock` in `.env`, `npm run dev`
2. Navigate to a topic that has `code-completion` widgets
3. Verify code block renders with inline inputs replacing `___`
4. Try clicking Submit without filling inputs — should be disabled
5. Fill all inputs — Submit should become active
6. Submit correct answer — all inputs turn green, `VerdictCard` appears with XP
7. Submit wrong answer — wrong inputs turn red with correct value shown below, correct inputs stay green
8. Verify hints appear below the code block
9. Switch to light theme — verify styles work correctly
10. `npm run lint` and `npm run build` — should pass without errors

## 📸 Screenshots / Demos
<img width="1431" height="518" alt="image" src="https://github.com/user-attachments/assets/6fc7b208-67c0-4909-b7c4-4c07a98150a7" />