### PR TITLE
fix: seed data to backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/backend/dist ./dist
 COPY --from=builder /app/backend/package.json ./package.json
+COPY --from=builder /app/backend/data/*.json ./data/
 
 # 8. Setup database directory
 RUN mkdir -p /app/data

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
     "dev": "ts-node-dev src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "seed": "ts-node src/seed.ts",
     "test": "vitest"
   },
   "dependencies": {

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -1,0 +1,12 @@
+import dataBase from "./database";
+import { fillDatabase } from "./add.widgets.data";
+
+console.log("[SEED] Starting manual database seeding...");
+
+try {
+  fillDatabase(dataBase);
+  console.log("[SEED] Manual seeding completed successfully.");
+} catch (error) {
+  console.error("[SEED] Error during manual seeding:", error);
+  throw error;
+}


### PR DESCRIPTION
## 📝 Overview

Added a manual database seeding utility to the backend. This allows developers to populate the storage with topics and widgets data from JSON files via a simple CLI command. This is particularly useful for initial production setups and Docker environments where automatic seeding might be skipped.

## 🚀 Changes

- **[NEW] [seed.ts](file:///Users/mercuryjuice/Yandex.Disk.localized/my-projects/codeVibeCheck/backend/src/seed.ts)**: A standalone script that imports the database instance and runs the [fillDatabase](file:///Users/mercuryjuice/Yandex.Disk.localized/my-projects/codeVibeCheck/backend/src/add.widgets.data.ts#332-354) sequence.
- **[MODIFY] [package.json](file:///Users/mercuryjuice/Yandex.Disk.localized/my-projects/codeVibeCheck/backend/package.json)**: Added `npm run seed` script to invoke `ts-node src/seed.ts`.

## 🧪 How to Test

1.  Navigate to the `backend` directory.
2.  Ensure your [.env](file:///Users/mercuryjuice/Yandex.Disk.localized/my-projects/codeVibeCheck/.env) and `data/*.json` files are present.
3.  Run the seeding command:
    ```bash
    npm run seed
    ```
4.  Verify in your SQLite client that the [topics](file:///Users/mercuryjuice/Yandex.Disk.localized/my-projects/codeVibeCheck/src/locale/en.ts#170-171) and `widgets` tables are now populated.

### Docker Verification
- Build and restart the container.
- Run the compiled script inside the container:
  ```bash
  docker exec -it <container_name> node dist/seed.js
  ```

## 📸 Screenshots / Demos

[N/A - CLI Utility]
